### PR TITLE
Selector

### DIFF
--- a/srcs/event_pool.hpp
+++ b/srcs/event_pool.hpp
@@ -36,14 +36,15 @@ class EventPool
 		}
 	}
 
-	Result<std::vector<int> > MonitorFds(ISelector *selector)
+	Result<void> MonitorFds(ISelector *selector, std::vector<int> &ready)
 	{
 		selector->Import(pool_.begin(), pool_.end()); //[TODO] allocate失敗
 		Result<void> res = selector->Run();
 		if (res.IsErr()) {
-			return Result<std::vector<int> >(res.err);
+			return res;
 		}
-		return selector->Export();
+		selector->Export(ready);
+		return Result<void>();
 	}
 
 	void TriggerEvents(const std::vector<int> &ready)

--- a/srcs/iselector.hpp
+++ b/srcs/iselector.hpp
@@ -2,6 +2,7 @@
 #define ISELECTOR_HPP
 
 #include <map>
+#include <vector>
 
 #include "event.hpp"
 #include "result.hpp"
@@ -14,7 +15,7 @@ class ISelector
   public:
 	virtual Result<void> Import(iterator begin, iterator end) = 0;
 	virtual Result<void> Run() = 0;
-	virtual const std::vector<int> &Export() = 0;
+	virtual void Export(std::vector<int> &ready) = 0;
 };
 
 #endif

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -30,11 +30,12 @@ int main()
 	ServersInit(pool, servers);
 	while (true) {
 		Selector selector;
-		Result<std::vector<int> > ret = pool.MonitorFds(&selector);
+		std::vector<int> ready;
+		Result<void> ret = pool.MonitorFds(&selector, ready);
 		if (ret.IsErr()) {
 			log("monitor", ret.Err());
 			continue;
 		}
-		pool.TriggerEvents(ret.Val());
+		pool.TriggerEvents(ready);
 	}
 }

--- a/srcs/select.cpp
+++ b/srcs/select.cpp
@@ -11,7 +11,7 @@ Select::Select()
 Select::~Select() {}
 
 Select::Select(Select const &copy)
-	: nfds_(copy.nfds_), read_set_(copy.read_set_), ready_(copy.ready_) {}
+	: nfds_(copy.nfds_), read_set_(copy.read_set_) {}
 
 //[TODO]
 Select &Select::operator=(Select const &other)
@@ -43,15 +43,14 @@ Result<void> Select::Run()
 	return Result<void>();
 }
 
-const std::vector<int> &Select::Export()
+void Select::Export(std::vector<int> &ready)
 {
 	for (int i = 0; i < nfds_; i++) {
 		if (FD_ISSET(i, &ready_set_)) {
-			ready_.push_back(i);
+			ready.push_back(i);
 		}
 		// if (FD_ISSET(fd, &set->write_set)) {
 		// 	event.Run();
 		// }
 	}
-	return ready_;
 }

--- a/srcs/select.hpp
+++ b/srcs/select.hpp
@@ -14,17 +14,13 @@ class Select : public ISelector
 	fd_set ready_set_;
 
   public:
-	std::vector<int>
-		ready_;
-
-  public:
 	Select();
 	~Select();
 	Select(Select const &copy);
 	Select &operator=(Select const &other);
 	Result<void> Import(iterator begin, iterator end);
 	Result<void> Run();
-	const std::vector<int> &Export();
+	void Export(std::vector<int> &ready);
 };
 
 #endif


### PR DESCRIPTION
Import() -> Run() -> Export()はprivateにして、この３つをラップして不可分にした
```std::vector<int> Run(iterator begin, iterator end);```
みたなメソッドだけをpublicにしてインターフェースとして公開する方がいいかも

あとExport()がconst参照を返してるのは良くないかも