### PR TITLE
fix: 🐛 timeoutの設定がnon-blocking-pool.empty()だとバグるので修正

### DIFF
--- a/srcs/epoll.cpp
+++ b/srcs/epoll.cpp
@@ -20,17 +20,17 @@ namespace io_multiplexer
 
 	Result<event::Events> Epoll::Wait()
 	{
-		Result<EpollEvents> wait_result     = WaitBlockingEvents();
-		event::Events       blocking_events = ConvertToEvents(wait_result.Val());
 		event::Events       events          = ExportNonBlockingEvents();
+		int                 timeout         = events.empty() ? timeout_ : 0;
+		Result<EpollEvents> wait_result     = WaitBlockingEvents(timeout);
+		event::Events       blocking_events = ConvertToEvents(wait_result.Val());
 		events.splice(events.end(), blocking_events);
 		return Result<event::Events>(events, Error(wait_result.Err()));
 	}
 
-	Result<EpollEvents> Epoll::WaitBlockingEvents()
+	Result<EpollEvents> Epoll::WaitBlockingEvents(int timeout)
 	{
 		int         num_of_events = blocking_pool_.size();
-		int         timeout       = non_blocking_pool_.empty() ? timeout_ : 0;
 		EpollEvents events(num_of_events);
 		EpollEvent *events_ptr = events.data();
 

--- a/srcs/epoll.hpp
+++ b/srcs/epoll.hpp
@@ -43,7 +43,7 @@ namespace io_multiplexer
 		Result<void>        Register(const event::Event &event);
 		Result<void>        Overwrite(const event::Event &event);
 		Result<void>        Unregister(const event::Event &event);
-		Result<EpollEvents> WaitBlockingEvents();
+		Result<EpollEvents> WaitBlockingEvents(int timeout);
 		event::Events       ExportNonBlockingEvents();
 		EpollEvent          ConvertToEpollEvent(const event::Event &event);
 		event::Event        ConvertToEvent(const EpollEvent &epoll_event);


### PR DESCRIPTION
event-typeがemptyのものを含めないように修正