### PR TITLE
fix: 🐛 stringをpush_backするときsize更新が漏れていたのを修正

### DIFF
--- a/srcs/buffer/queuing_buffer.cpp
+++ b/srcs/buffer/queuing_buffer.cpp
@@ -24,6 +24,7 @@ namespace q_buffer
 			return;
 		}
 		buf_.push_back(ByteArray(data.begin(), data.end()));
+		size_ += data.size();
 	}
 
 	Emptiable<char> QueuingBuffer::PopChar()


### PR DESCRIPTION
fix #263